### PR TITLE
Fix incorrect initialization of paubox_client in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ from config import Config
 config_file = file("config.cfg")
 paubox_config = Config(config_file)
 
-paubox_client = paubox.PauboxApiClient( paubox_config.PAUBOX_HOST, paubox_config.PAUBOX_API_KEY)
+paubox_client = paubox.PauboxApiClient(paubox_config.PAUBOX_API_KEY, paubox_config.PAUBOX_HOST)
 recipients = ["recipient@example.com"]
 from_ = "sender@yourdomain.com"
 subject = "Testing!"


### PR DESCRIPTION
Swapped the order of the parameters in the "Send Messages with Paubox Mail Helper" section. The current order, passing in HOST before API Key, throws an error because the class is initiated with the host attribute assigned to the API Key and API Key attribute assigned to host.